### PR TITLE
Remove the __len__ method

### DIFF
--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -534,20 +534,6 @@ def encode_varint(value: int) -> bytes:
         return stream.getvalue()
 
 
-def size_varint(value: int) -> int:
-    """Calculates the size in bytes that a value would take as a varint."""
-    if value < -(1 << 63):
-        raise ValueError(
-            "Negative value is not representable as a 64-bit integer - unable to encode a varint within 10 bytes."
-        )
-    elif value < 0:
-        return 10
-    elif value == 0:
-        return 1
-    else:
-        return math.ceil(value.bit_length() / 7)
-
-
 def _preprocess_single(proto_type: str, wraps: str, value: Any) -> bytes:
     """Adjusts values before serialization."""
     if proto_type in (
@@ -583,41 +569,6 @@ def _preprocess_single(proto_type: str, wraps: str, value: Any) -> bytes:
     return value
 
 
-def _len_preprocessed_single(proto_type: str, wraps: str, value: Any) -> int:
-    """Calculate the size of adjusted values for serialization without fully serializing them."""
-    if proto_type in (
-        TYPE_ENUM,
-        TYPE_BOOL,
-        TYPE_INT32,
-        TYPE_INT64,
-        TYPE_UINT32,
-        TYPE_UINT64,
-    ):
-        return size_varint(value)
-    elif proto_type in (TYPE_SINT32, TYPE_SINT64):
-        # Handle zig-zag encoding.
-        return size_varint(value << 1 if value >= 0 else (value << 1) ^ (~0))
-    elif proto_type in FIXED_TYPES:
-        return len(struct.pack(_pack_fmt(proto_type), value))
-    elif proto_type == TYPE_STRING:
-        return len(value.encode("utf-8"))
-    elif proto_type == TYPE_MESSAGE:
-        if isinstance(value, datetime):
-            # Convert the `datetime` to a timestamp message.
-            value = _Timestamp.from_datetime(value)
-        elif isinstance(value, timedelta):
-            # Convert the `timedelta` to a duration message.
-            value = _Duration.from_timedelta(value)
-        elif wraps:
-            if value is None:
-                return 0
-            value = _get_wrapper(wraps)(value=value)
-
-        return len(bytes(value))
-
-    return len(value)
-
-
 def _serialize_single(
     field_number: int,
     proto_type: str,
@@ -647,31 +598,6 @@ def _serialize_single(
         raise NotImplementedError(proto_type)
 
     return bytes(output)
-
-
-def _len_single(
-    field_number: int,
-    proto_type: str,
-    value: Any,
-    *,
-    serialize_empty: bool = False,
-    wraps: str = "",
-) -> int:
-    """Calculates the size of a serialized single field and value."""
-    size = _len_preprocessed_single(proto_type, wraps, value)
-    if proto_type in WIRE_VARINT_TYPES:
-        size += size_varint(field_number << 3)
-    elif proto_type in WIRE_FIXED_32_TYPES:
-        size += size_varint((field_number << 3) | 5)
-    elif proto_type in WIRE_FIXED_64_TYPES:
-        size += size_varint((field_number << 3) | 1)
-    elif proto_type in WIRE_LEN_DELIM_TYPES:
-        if size or serialize_empty or wraps:
-            size += size_varint((field_number << 3) | 2) + size_varint(size)
-    else:
-        raise NotImplementedError(proto_type)
-
-    return size
 
 
 def _parse_float(value: Any) -> float:
@@ -1031,199 +957,111 @@ class Message(ABC):
         delimit:
             Whether to prefix the message with a varint declaring its size.
         """
+        b = bytes(self)
+
         if delimit == SIZE_DELIMITED:
-            dump_varint(len(self), stream)
+            dump_varint(len(b), stream)
 
-        for field_name, meta in self._betterproto.meta_by_field_name.items():
-            value = getattr(self, field_name)
-
-            if value is None:
-                # Optional items should be skipped. This is used for the Google
-                # wrapper types and proto3 field presence/optional fields.
-                continue
-
-            # Being selected in a a group means this field is the one that is
-            # currently set in a `oneof` group, so it must be serialized even
-            # if the value is the default zero value.
-            #
-            # Note that proto3 field presence/optional fields are put in a
-            # synthetic single-item oneof by protoc, which helps us ensure we
-            # send the value even if the value is the default zero value.
-            selected_in_group = bool(meta.group) or meta.optional
-
-            # Empty messages can still be sent on the wire if they were
-            # set (or received empty).
-            # TODO this is here for historical reasons, now if a message is defined (ie not None), it should be sent
-            serialize_empty = isinstance(value, Message)
-
-            include_default_value_for_oneof = self._include_default_value_for_oneof(
-                field_name=field_name, meta=meta
-            )
-
-            if value == self._get_field_default(field_name) and not (
-                selected_in_group or serialize_empty or include_default_value_for_oneof
-            ):
-                # Default (zero) values are not serialized. Two exceptions are
-                # if this is the selected oneof item or if we know we have to
-                # serialize an empty message (i.e. zero value was explicitly
-                # set by the user).
-                continue
-
-            if isinstance(value, list):
-                if meta.proto_type in PACKED_TYPES:
-                    # Packed lists look like a length-delimited field. First,
-                    # preprocess/encode each value into a buffer and then
-                    # treat it like a field of raw bytes.
-                    buf = bytearray()
-                    for item in value:
-                        buf += _preprocess_single(meta.proto_type, "", item)
-                    stream.write(_serialize_single(meta.number, TYPE_BYTES, buf))
-                else:
-                    for item in value:
-                        stream.write(
-                            _serialize_single(
-                                meta.number,
-                                meta.proto_type,
-                                item,
-                                wraps=meta.wraps or "",
-                                serialize_empty=True,
-                            )
-                            # if it's an empty message it still needs to be represented
-                            # as an item in the repeated list
-                            or b"\n\x00"
-                        )
-
-            elif isinstance(value, dict):
-                for k, v in value.items():
-                    assert meta.map_types
-                    sk = _serialize_single(1, meta.map_types[0], k)
-                    sv = _serialize_single(2, meta.map_types[1], v)
-                    stream.write(
-                        _serialize_single(meta.number, meta.proto_type, sk + sv)
-                    )
-            else:
-                # If we have an empty string and we're including the default value for
-                # a oneof, make sure we serialize it. This ensures that the byte string
-                # output isn't simply an empty string. This also ensures that round trip
-                # serialization will keep `which_one_of` calls consistent.
-                if (
-                    isinstance(value, str)
-                    and value == ""
-                    and include_default_value_for_oneof
-                ):
-                    serialize_empty = True
-
-                stream.write(
-                    _serialize_single(
-                        meta.number,
-                        meta.proto_type,
-                        value,
-                        serialize_empty=serialize_empty or bool(selected_in_group),
-                        wraps=meta.wraps or "",
-                    )
-                )
-
-        stream.write(self._unknown_fields)
+        stream.write(b)
 
     def __bytes__(self) -> bytes:
         """
         Get the binary encoded Protobuf representation of this message instance.
         """
         with BytesIO() as stream:
-            self.dump(stream)
-            return stream.getvalue()
+            for field_name, meta in self._betterproto.meta_by_field_name.items():
+                value = getattr(self, field_name)
 
-    def __len__(self) -> int:
-        """
-        Get the size of the encoded Protobuf representation of this message instance.
-        """
-        size = 0
-        for field_name, meta in self._betterproto.meta_by_field_name.items():
-            value = getattr(self, field_name)
+                if value is None:
+                    # Optional items should be skipped. This is used for the Google
+                    # wrapper types and proto3 field presence/optional fields.
+                    continue
 
-            if value is None:
-                # Optional items should be skipped. This is used for the Google
-                # wrapper types and proto3 field presence/optional fields.
-                continue
+                # Being selected in a a group means this field is the one that is
+                # currently set in a `oneof` group, so it must be serialized even
+                # if the value is the default zero value.
+                #
+                # Note that proto3 field presence/optional fields are put in a
+                # synthetic single-item oneof by protoc, which helps us ensure we
+                # send the value even if the value is the default zero value.
+                selected_in_group = bool(meta.group) or meta.optional
 
-            # Being selected in a group means this field is the one that is
-            # currently set in a `oneof` group, so it must be serialized even
-            # if the value is the default zero value.
-            #
-            # Note that proto3 field presence/optional fields are put in a
-            # synthetic single-item oneof by protoc, which helps us ensure we
-            # send the value even if the value is the default zero value.
-            selected_in_group = bool(meta.group)
+                # Empty messages can still be sent on the wire if they were
+                # set (or received empty).
+                # TODO this is here for historical reasons, now if a message is defined (ie not None), it should be sent
+                serialize_empty = isinstance(value, Message)
 
-            # Empty messages can still be sent on the wire if they were
-            # set (or received empty).
-            serialize_empty = isinstance(value, Message)
-
-            include_default_value_for_oneof = self._include_default_value_for_oneof(
-                field_name=field_name, meta=meta
-            )
-
-            if value == self._get_field_default(field_name) and not (
-                selected_in_group or serialize_empty or include_default_value_for_oneof
-            ):
-                # Default (zero) values are not serialized. Two exceptions are
-                # if this is the selected oneof item or if we know we have to
-                # serialize an empty message (i.e. zero value was explicitly
-                # set by the user).
-                continue
-
-            if isinstance(value, list):
-                if meta.proto_type in PACKED_TYPES:
-                    # Packed lists look like a length-delimited field. First,
-                    # preprocess/encode each value into a buffer and then
-                    # treat it like a field of raw bytes.
-                    buf = bytearray()
-                    for item in value:
-                        buf += _preprocess_single(meta.proto_type, "", item)
-                    size += _len_single(meta.number, TYPE_BYTES, buf)
-                else:
-                    for item in value:
-                        size += (
-                            _len_single(
-                                meta.number,
-                                meta.proto_type,
-                                item,
-                                wraps=meta.wraps or "",
-                                serialize_empty=True,
-                            )
-                            # if it's an empty message it still needs to be represented
-                            # as an item in the repeated list
-                            or 2
-                        )
-
-            elif isinstance(value, dict):
-                for k, v in value.items():
-                    assert meta.map_types
-                    sk = _serialize_single(1, meta.map_types[0], k)
-                    sv = _serialize_single(2, meta.map_types[1], v)
-                    size += _len_single(meta.number, meta.proto_type, sk + sv)
-            else:
-                # If we have an empty string and we're including the default value for
-                # a oneof, make sure we serialize it. This ensures that the byte string
-                # output isn't simply an empty string. This also ensures that round trip
-                # serialization will keep `which_one_of` calls consistent.
-                if (
-                    isinstance(value, str)
-                    and value == ""
-                    and include_default_value_for_oneof
-                ):
-                    serialize_empty = True
-
-                size += _len_single(
-                    meta.number,
-                    meta.proto_type,
-                    value,
-                    serialize_empty=serialize_empty or bool(selected_in_group),
-                    wraps=meta.wraps or "",
+                include_default_value_for_oneof = self._include_default_value_for_oneof(
+                    field_name=field_name, meta=meta
                 )
 
-        size += len(self._unknown_fields)
-        return size
+                if value == self._get_field_default(field_name) and not (
+                    selected_in_group
+                    or serialize_empty
+                    or include_default_value_for_oneof
+                ):
+                    # Default (zero) values are not serialized. Two exceptions are
+                    # if this is the selected oneof item or if we know we have to
+                    # serialize an empty message (i.e. zero value was explicitly
+                    # set by the user).
+                    continue
+
+                if isinstance(value, list):
+                    if meta.proto_type in PACKED_TYPES:
+                        # Packed lists look like a length-delimited field. First,
+                        # preprocess/encode each value into a buffer and then
+                        # treat it like a field of raw bytes.
+                        buf = bytearray()
+                        for item in value:
+                            buf += _preprocess_single(meta.proto_type, "", item)
+                        stream.write(_serialize_single(meta.number, TYPE_BYTES, buf))
+                    else:
+                        for item in value:
+                            stream.write(
+                                _serialize_single(
+                                    meta.number,
+                                    meta.proto_type,
+                                    item,
+                                    wraps=meta.wraps or "",
+                                    serialize_empty=True,
+                                )
+                                # if it's an empty message it still needs to be represented
+                                # as an item in the repeated list
+                                or b"\n\x00"
+                            )
+
+                elif isinstance(value, dict):
+                    for k, v in value.items():
+                        assert meta.map_types
+                        sk = _serialize_single(1, meta.map_types[0], k)
+                        sv = _serialize_single(2, meta.map_types[1], v)
+                        stream.write(
+                            _serialize_single(meta.number, meta.proto_type, sk + sv)
+                        )
+                else:
+                    # If we have an empty string and we're including the default value for
+                    # a oneof, make sure we serialize it. This ensures that the byte string
+                    # output isn't simply an empty string. This also ensures that round trip
+                    # serialization will keep `which_one_of` calls consistent.
+                    if (
+                        isinstance(value, str)
+                        and value == ""
+                        and include_default_value_for_oneof
+                    ):
+                        serialize_empty = True
+
+                    stream.write(
+                        _serialize_single(
+                            meta.number,
+                            meta.proto_type,
+                            value,
+                            serialize_empty=serialize_empty or bool(selected_in_group),
+                            wraps=meta.wraps or "",
+                        )
+                    )
+
+            stream.write(self._unknown_fields)
+            return stream.getvalue()
 
     # For compatibility with other libraries
     def SerializeToString(self: T) -> bytes:

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -956,6 +956,7 @@ class Message(ABC):
             The stream to dump the message to.
         delimit:
             Whether to prefix the message with a varint declaring its size.
+            TODO is it actually needed?
         """
         b = bytes(self)
 

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -959,7 +959,7 @@ class Message(ABC):
         """
         b = bytes(self)
 
-        if delimit == SIZE_DELIMITED:
+        if delimit:
             dump_varint(len(b), stream)
 
         stream.write(b)

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -133,9 +133,9 @@ def test_message_dump_file_multiple(tmp_path):
 
 def test_message_dump_delimited(tmp_path):
     with open(tmp_path / "message_dump_delimited.out", "wb") as stream:
-        oneof_example.dump(stream, betterproto.SIZE_DELIMITED)
-        oneof_example.dump(stream, betterproto.SIZE_DELIMITED)
-        nested_example.dump(stream, betterproto.SIZE_DELIMITED)
+        oneof_example.dump(stream, True)
+        oneof_example.dump(stream, True)
+        nested_example.dump(stream, True)
 
     with open(tmp_path / "message_dump_delimited.out", "rb") as test_stream, open(
         streams_path / "delimited_messages.in", "rb"
@@ -340,8 +340,8 @@ def test_single_message(compile_jar, tmp_path):
 def test_multiple_messages(compile_jar, tmp_path):
     # Write delimited messages to file
     with open(tmp_path / "py_multiple_messages.out", "wb") as stream:
-        oneof_example.dump(stream, betterproto.SIZE_DELIMITED)
-        nested_example.dump(stream, betterproto.SIZE_DELIMITED)
+        oneof_example.dump(stream, True)
+        nested_example.dump(stream, True)
 
     # Have Java read and return the messages
     run_jar("multiple_messages", tmp_path)
@@ -362,7 +362,7 @@ def test_infinite_messages(compile_jar, tmp_path):
     # Write delimited messages to file
     with open(tmp_path / "py_infinite_messages.out", "wb") as stream:
         for x in range(num_messages):
-            oneof_example.dump(stream, betterproto.SIZE_DELIMITED)
+            oneof_example.dump(stream, True)
 
     # Have Java read and return the messages
     run_jar("infinite_messages", tmp_path)

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -21,7 +21,7 @@ oneof_example = oneof.Test().from_dict(
     {"pitied": 1, "just_a_regular_field": 123456789, "bar_name": "Testing"}
 )
 
-len_oneof = len(oneof_example)
+len_oneof = len(bytes(oneof_example))
 
 nested_example = nested.Test().from_dict(
     {
@@ -143,11 +143,6 @@ def test_message_dump_delimited(tmp_path):
         assert test_stream.read() == exp_stream.read()
 
 
-def test_message_len():
-    assert len_oneof == len(bytes(oneof_example))
-    assert len(nested_example) == len(bytes(nested_example))
-
-
 def test_message_load_file_single():
     with open(streams_path / "message_dump_file_single.expected", "rb") as stream:
         assert oneof.Test().load(stream) == oneof_example
@@ -186,74 +181,24 @@ def test_message_load_too_large():
         oneof.Test().load(stream, len_oneof + 1)
 
 
-def test_message_len_optional_field():
-    @dataclass
-    class Request(betterproto.Message):
-        flag: Optional[bool] = betterproto.message_field(1, wraps=betterproto.TYPE_BOOL)
-
-    assert len(Request()) == len(b"")
-    assert len(Request(flag=True)) == len(b"\n\x02\x08\x01")
-    assert len(Request(flag=False)) == len(b"\n\x00")
-
-
-def test_message_len_repeated_field():
-    assert len(repeated_example) == len(bytes(repeated_example))
-
-
-def test_message_len_packed_field():
-    assert len(packed_example) == len(bytes(packed_example))
-
-
-def test_message_len_map_field():
-    assert len(map_example) == len(bytes(map_example))
-
-
-def test_message_len_empty_string():
-    @dataclass
-    class Empty(betterproto.Message):
-        string: str = betterproto.string_field(1, "group")
-        integer: int = betterproto.int32_field(2, "group")
-
-    empty = Empty().from_dict({"string": ""})
-    assert len(empty) == len(bytes(empty))
-
-
 def test_calculate_varint_size_negative():
     single_byte = -1
     multi_byte = -10000000
     edge = -(1 << 63)
-    beyond = -(1 << 63) - 1
     before = -(1 << 63) + 1
 
-    assert (
-        betterproto.size_varint(single_byte)
-        == len(betterproto.encode_varint(single_byte))
-        == 10
-    )
-    assert (
-        betterproto.size_varint(multi_byte)
-        == len(betterproto.encode_varint(multi_byte))
-        == 10
-    )
-    assert betterproto.size_varint(edge) == len(betterproto.encode_varint(edge)) == 10
-    assert (
-        betterproto.size_varint(before) == len(betterproto.encode_varint(before)) == 10
-    )
-
-    with pytest.raises(ValueError):
-        betterproto.size_varint(beyond)
+    assert len(betterproto.encode_varint(single_byte)) == 10
+    assert len(betterproto.encode_varint(multi_byte)) == 10
+    assert len(betterproto.encode_varint(edge)) == 10
+    assert len(betterproto.encode_varint(before)) == 10
 
 
 def test_calculate_varint_size_positive():
     single_byte = 1
     multi_byte = 10000000
 
-    assert betterproto.size_varint(single_byte) == len(
-        betterproto.encode_varint(single_byte)
-    )
-    assert betterproto.size_varint(multi_byte) == len(
-        betterproto.encode_varint(multi_byte)
-    )
+    assert len(betterproto.encode_varint(single_byte))
+    assert len(betterproto.encode_varint(multi_byte))
 
 
 def test_dump_varint_negative(tmp_path):


### PR DESCRIPTION
Messages used to define a `__len__` method. It was used to add the len of a message before the message itself.

Almost of the code was duplicated.