### PR TITLE
Simplify rpc calls with empty input message

### DIFF
--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -64,8 +64,7 @@ from betterproto.lib.google.protobuf import (
 )
 from betterproto.lib.google.protobuf.compiler import CodeGeneratorRequest
 
-from .. import which_one_of
-from ..compile.importing import get_type_reference
+from ..compile.importing import get_type_reference, parse_source_type_name
 from ..compile.naming import (
     pythonize_class_name,
     pythonize_enum_member_name,
@@ -702,6 +701,14 @@ class ServiceMethodCompiler(ProtoContentBase):
             unwrap=False,
             pydantic=self.output_file.pydantic_dataclasses,
         ).strip('"')
+
+    @property
+    def is_input_msg_empty(self: "ServiceMethodCompiler") -> bool:
+        package, name = parse_source_type_name(self.proto_obj.input_type, self.request)
+
+        msg = self.request.output_packages[package].messages[name]
+
+        return not bool(msg.fields)
 
     @property
     def py_input_message_param(self) -> str:

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -83,7 +83,12 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
     {% for method in service.methods %}
     async def {{ method.py_name }}(self
         {%- if not method.client_streaming -%}
-            , {{ method.py_input_message_param }}: "{{ method.py_input_message_type }}"
+            , {{ method.py_input_message_param }}:
+                {%- if method.is_input_msg_empty -%}
+                    "{{ method.py_input_message_type }} | None" = None
+                {%- else -%}
+                    "{{ method.py_input_message_type }}"
+                {%- endif -%}
         {%- else -%}
             {# Client streaming: need a request iterator instead #}
             , {{ method.py_input_message_param }}_iterator: "{{ output_file.typing_compiler.union(output_file.typing_compiler.async_iterable(method.py_input_message_type), output_file.typing_compiler.iterable(method.py_input_message_type)) }}"
@@ -117,6 +122,11 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
         ):
             yield response
             {% else %}{# i.e. not client streaming #}
+        {% if method.is_input_msg_empty %}
+        if {{ method.py_input_message_param }} is None:
+            {{ method.py_input_message_param }} = {{ method.py_input_message_type }}()
+
+        {% endif %}
         async for response in self._unary_stream(
             "{{ method.route }}",
             {{ method.py_input_message_param }},
@@ -140,6 +150,11 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
             metadata=metadata,
         )
             {% else %}{# i.e. not client streaming #}
+        {% if method.is_input_msg_empty %}
+        if {{ method.py_input_message_param }} is None:
+            {{ method.py_input_message_param }} = {{ method.py_input_message_type }}()
+
+        {% endif %}
         return await self._unary_unary(
             "{{ method.route }}",
             {{ method.py_input_message_param }},

--- a/tests/inputs/rpc_empty_input_message/rpc_empty_input_message.proto
+++ b/tests/inputs/rpc_empty_input_message/rpc_empty_input_message.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package rpc_empty_input_message;
+
+message Test {}
+
+message Response {
+    int32 v = 1;
+}
+
+service Service {
+    rpc read(Test) returns (Response);
+}

--- a/tests/inputs/rpc_empty_input_message/test_rpc_empty_input_message.py
+++ b/tests/inputs/rpc_empty_input_message/test_rpc_empty_input_message.py
@@ -1,0 +1,24 @@
+import pytest
+from grpclib.testing import ChannelFor
+
+
+@pytest.mark.asyncio
+async def test_rpc_input_message():
+    from tests.output_betterproto.rpc_empty_input_message import (
+        Response,
+        ServiceBase,
+        ServiceStub,
+        Test,
+    )
+
+    class Service(ServiceBase):
+        async def read(self, test: "Test") -> "Response":
+            return Response(v=42)
+
+    async with ChannelFor([Service()]) as channel:
+        client = ServiceStub(channel)
+
+        assert (await client.read(Test())).v == 42
+
+        # Check that we can call the method without providing the message
+        assert (await client.read()).v == 42


### PR DESCRIPTION
This makes it easier to call an rpc with an empty input message: there is now a default value.