### PR TITLE
Add the quotes around types only at the end

### DIFF
--- a/src/betterproto/compile/importing.py
+++ b/src/betterproto/compile/importing.py
@@ -131,14 +131,14 @@ def reference_absolute(imports: Set[str], py_package: List[str], py_type: str) -
     string_import = ".".join(py_package)
     string_alias = safe_snake_case(string_import)
     imports.add(f"import {string_import} as {string_alias}")
-    return f'"{string_alias}.{py_type}"'
+    return f"{string_alias}.{py_type}"
 
 
 def reference_sibling(py_type: str) -> str:
     """
     Returns a reference to a python type within the same package as the current package.
     """
-    return f'"{py_type}"'
+    return f"{py_type}"
 
 
 def reference_descendent(
@@ -155,10 +155,10 @@ def reference_descendent(
     if string_from:
         string_alias = "_".join(importing_descendent)
         imports.add(f"from .{string_from} import {string_import} as {string_alias}")
-        return f'"{string_alias}.{py_type}"'
+        return f"{string_alias}.{py_type}"
     else:
         imports.add(f"from . import {string_import}")
-        return f'"{string_import}.{py_type}"'
+        return f"{string_import}.{py_type}"
 
 
 def reference_ancestor(
@@ -177,11 +177,11 @@ def reference_ancestor(
         string_alias = f"_{'_' * distance_up}{string_import}__"
         string_from = f"..{'.' * distance_up}"
         imports.add(f"from {string_from} import {string_import} as {string_alias}")
-        return f'"{string_alias}.{py_type}"'
+        return f"{string_alias}.{py_type}"
     else:
         string_alias = f"{'_' * distance_up}{py_type}__"
         imports.add(f"from .{'.' * distance_up} import {py_type} as {string_alias}")
-        return f'"{string_alias}"'
+        return string_alias
 
 
 def reference_cousin(
@@ -204,4 +204,4 @@ def reference_cousin(
         + "__"
     )
     imports.add(f"from {string_from} import {string_import} as {string_alias}")
-    return f'"{string_alias}.{py_type}"'
+    return f"{string_alias}.{py_type}"

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -405,7 +405,6 @@ class FieldCompiler(ProtoContentBase):
     def get_field_string(self) -> str:
         """Construct string representation of this field as a field."""
         name = f"{self.py_name}"
-        annotations = f": {self.annotation}"
         field_args = ", ".join(
             ([""] + self.betterproto_field_args) if self.betterproto_field_args else []
         )
@@ -414,7 +413,7 @@ class FieldCompiler(ProtoContentBase):
         )
         if self.py_name in dir(builtins):
             self.parent.builtins_types.add(self.py_name)
-        return f"{name}{annotations} = {betterproto_field_type}"
+        return f'{name}: "{self.annotation}" = {betterproto_field_type}'
 
     @property
     def betterproto_field_args(self) -> List[str]:
@@ -426,7 +425,7 @@ class FieldCompiler(ProtoContentBase):
         if self.repeated:
             args.append("repeated=True")
         if self.field_type == "enum":
-            t = self.py_type.strip('"')
+            t = self.py_type
             args.append(f"enum_default_value=lambda: {t}.try_value(0)")
         return args
 
@@ -702,7 +701,7 @@ class ServiceMethodCompiler(ProtoContentBase):
             request=self.request,
             unwrap=False,
             pydantic=self.output_file.pydantic_dataclasses,
-        ).strip('"')
+        )
 
     @property
     def is_input_msg_empty(self: "ServiceMethodCompiler") -> bool:
@@ -741,7 +740,7 @@ class ServiceMethodCompiler(ProtoContentBase):
             request=self.request,
             unwrap=False,
             pydantic=self.output_file.pydantic_dataclasses,
-        ).strip('"')
+        )
 
     @property
     def client_streaming(self) -> bool:

--- a/src/betterproto/plugin/typing_compiler.py
+++ b/src/betterproto/plugin/typing_compiler.py
@@ -139,35 +139,29 @@ class TypingImportTypingCompiler(TypingCompiler):
 class NoTyping310TypingCompiler(TypingCompiler):
     _imports: Dict[str, Set[str]] = field(default_factory=lambda: defaultdict(set))
 
-    @staticmethod
-    def _fmt(type: str) -> str:  # for now this is necessary till 3.14
-        if type.startswith('"'):
-            return type[1:-1]
-        return type
-
     def optional(self, type: str) -> str:
-        return f'"{self._fmt(type)} | None"'
+        return f"{type} | None"
 
     def list(self, type: str) -> str:
-        return f'"list[{self._fmt(type)}]"'
+        return f"list[{type}]"
 
     def dict(self, key: str, value: str) -> str:
-        return f'"dict[{key}, {self._fmt(value)}]"'
+        return f"dict[{key}, {value}]"
 
     def union(self, *types: str) -> str:
-        return f'"{" | ".join(map(self._fmt, types))}"'
+        return f"{' | '.join(types)}"
 
     def iterable(self, type: str) -> str:
         self._imports["collections.abc"].add("Iterable")
-        return f'"Iterable[{type}]"'
+        return f"Iterable[{type}]"
 
     def async_iterable(self, type: str) -> str:
         self._imports["collections.abc"].add("AsyncIterable")
-        return f'"AsyncIterable[{type}]"'
+        return f"AsyncIterable[{type}]"
 
     def async_iterator(self, type: str) -> str:
         self._imports["collections.abc"].add("AsyncIterator")
-        return f'"AsyncIterator[{type}]"'
+        return f"AsyncIterator[{type}]"
 
     def imports(self) -> Dict[str, Optional[Set[str]]]:
         return {k: v if v else None for k, v in self._imports.items()}

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -96,8 +96,8 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
             ,
             *
             , timeout: {{ output_file.typing_compiler.optional("float") }} = None
-            , deadline: {{ output_file.typing_compiler.optional('"Deadline"') }} = None
-            , metadata: {{ output_file.typing_compiler.optional('"MetadataLike"') }} = None
+            , deadline: "{{ output_file.typing_compiler.optional("Deadline") }}" = None
+            , metadata: "{{ output_file.typing_compiler.optional("MetadataLike") }}" = None
             ) -> "{% if method.server_streaming %}{{ output_file.typing_compiler.async_iterator(method.py_output_message_type ) }}{% else %}{{ method.py_output_message_type }}{% endif %}":
         {% if method.comment %}
         """
@@ -115,7 +115,7 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
             "{{ method.route }}",
             {{ method.py_input_message_param }}_iterator,
             {{ method.py_input_message_type }},
-            {{ method.py_output_message_type.strip('"') }},
+            {{ method.py_output_message_type }},
             timeout=timeout,
             deadline=deadline,
             metadata=metadata,
@@ -130,7 +130,7 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
         async for response in self._unary_stream(
             "{{ method.route }}",
             {{ method.py_input_message_param }},
-            {{ method.py_output_message_type.strip('"') }},
+            {{ method.py_output_message_type }},
             timeout=timeout,
             deadline=deadline,
             metadata=metadata,
@@ -144,7 +144,7 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
             "{{ method.route }}",
             {{ method.py_input_message_param }}_iterator,
             {{ method.py_input_message_type }},
-            {{ method.py_output_message_type.strip('"') }},
+            {{ method.py_output_message_type }},
             timeout=timeout,
             deadline=deadline,
             metadata=metadata,
@@ -158,7 +158,7 @@ class {{ service.py_name }}Stub(betterproto.ServiceStub):
         return await self._unary_unary(
             "{{ method.route }}",
             {{ method.py_input_message_param }},
-            {{ method.py_output_message_type.strip('"') }},
+            {{ method.py_output_message_type }},
             timeout=timeout,
             deadline=deadline,
             metadata=metadata,

--- a/tests/test_typing_compiler.py
+++ b/tests/test_typing_compiler.py
@@ -62,17 +62,17 @@ def test_typing_import_typing_compiler():
 def test_no_typing_311_typing_compiler():
     compiler = NoTyping310TypingCompiler()
     assert compiler.imports() == {}
-    assert compiler.optional("str") == '"str | None"'
+    assert compiler.optional("str") == "str | None"
     assert compiler.imports() == {}
-    assert compiler.list("str") == '"list[str]"'
+    assert compiler.list("str") == "list[str]"
     assert compiler.imports() == {}
-    assert compiler.dict("str", "int") == '"dict[str, int]"'
+    assert compiler.dict("str", "int") == "dict[str, int]"
     assert compiler.imports() == {}
-    assert compiler.union("str", "int") == '"str | int"'
+    assert compiler.union("str", "int") == "str | int"
     assert compiler.imports() == {}
-    assert compiler.iterable("str") == '"Iterable[str]"'
-    assert compiler.async_iterable("str") == '"AsyncIterable[str]"'
-    assert compiler.async_iterator("str") == '"AsyncIterator[str]"'
+    assert compiler.iterable("str") == "Iterable[str]"
+    assert compiler.async_iterable("str") == "AsyncIterable[str]"
+    assert compiler.async_iterator("str") == "AsyncIterator[str]"
     assert compiler.imports() == {
         "collections.abc": {"Iterable", "AsyncIterable", "AsyncIterator"}
     }


### PR DESCRIPTION
## Summary

This simplifies the way quotes are added around type annotations by adding them only at the very end. This avoid adding `strip('"')` a bit everywhere in the code.