### PR TITLE
Add lib / compiler compatibility check

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -22,6 +22,13 @@ e.g.
 python3 -m pip install -U "betterproto[compiler]"
 ```
 
+!!! warning
+    Make sure that the proto files were generated with a version of `betterproto2_compiler` that is compatible with your
+    version of `betterproto2`.
+
+    The version `x.y.z` of `betterproto` is compatible with the version `a.b.c` of the compiler if and only if `a=x` and
+    `b=y`.
+
 ## Compiling proto files
 
 

--- a/src/betterproto2/__init__.py
+++ b/src/betterproto2/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "check_compiler_version"]
 
 import dataclasses
 import enum as builtin_enum
@@ -44,7 +44,7 @@ from dateutil.parser import isoparse
 from typing_extensions import Self
 
 from ._types import T
-from ._version import __version__
+from ._version import __version__, check_compiler_version
 from .casing import (
     camel_case,
     safe_snake_case,

--- a/src/betterproto2/_version.py
+++ b/src/betterproto2/_version.py
@@ -1,3 +1,38 @@
 from importlib import metadata
 
 __version__ = metadata.version("betterproto2")
+
+
+def check_compiler_version(compiler_version: str) -> None:
+    """
+    Checks that the compiled files can be used with this version of the library.
+
+    If the versions do not match, the user is suggested to update the library or the compiler. The version x.y.z of the
+    library matches the version a.b.c of the compiler if and only if a=x and b=y.
+    """
+    parsed_lib_version = tuple(int(x) for x in __version__.split(".")[:2])
+    parsed_comp_version = tuple(int(x) for x in compiler_version.split(".")[:2])
+
+    if parsed_lib_version != parsed_comp_version:
+        error = (
+            f"Unsupported version. The proto files were compiled with a version of betterproto2_compiler which is not "
+            "compatible with this version of betterproto2.\n"
+            f" - betterproto2 version: {__version__}\n"
+            f" - betterproto2_compiler version: {compiler_version}\n"
+            "The version x.y.z of the library matches the version a.b.c of the compiler if and only if a=x and b=y.\n"
+        )
+
+        if parsed_lib_version < parsed_comp_version:
+            error += (
+                f"Please upgrade betterproto2 to {parsed_comp_version[0]}.{parsed_comp_version[1]}.x (recommended) "
+                f"or downgrade betterproto2_compiler to {parsed_lib_version[0]}.{parsed_lib_version[1]}.x and "
+                "recompile your proto files."
+            )
+        else:
+            error += (
+                f"Please upgrade betterproto2_compiler to {parsed_lib_version[0]}.{parsed_lib_version[1]}.x and "
+                "recompile your proto files (recommended) or downgrade betterproto2 to "
+                f"{parsed_comp_version[0]}.{parsed_comp_version[1]}.x."
+            )
+
+        raise ImportError(error)

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+def test_check_compiler_version():
+    from betterproto2 import __version__, check_compiler_version
+
+    x, y, z = (int(x) for x in __version__.split("."))
+
+    check_compiler_version(__version__)
+    check_compiler_version(f"{x}.{y}.{z-1}")
+    check_compiler_version(f"{x}.{y}.{z+1}")
+
+    with pytest.raises(ImportError):
+        check_compiler_version(f"{x}.{y-1}.{z}")
+
+    with pytest.raises(ImportError):
+        check_compiler_version(f"{x}.{y+1}.{z}")
+
+    with pytest.raises(ImportError):
+        check_compiler_version(f"{x+1}.{y}.{z}")
+
+    with pytest.raises(ImportError):
+        check_compiler_version(f"{x-1}.{y}.{z}")


### PR DESCRIPTION
Adds a function that can be called to make sure that the proto files were compiled with a compatible version of the compiler.