### PR TITLE
Greatly simplify enums implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "betterproto2"
-version = "0.2.3"
+version = "0.3.0"
 description = "A better Protobuf / gRPC generator & library"
 authors = [
     {name = "Adrien Vannson", email = "adrien.vannson@protonmail.com"},

--- a/src/betterproto2/__init__.py
+++ b/src/betterproto2/__init__.py
@@ -823,7 +823,7 @@ class Message(ABC):
                 value = value > 0
             elif meta.proto_type == TYPE_ENUM:
                 # Convert enum ints to python enum instances
-                value = self._betterproto.cls_by_field[field_name].try_value(value)
+                value = self._betterproto.cls_by_field[field_name](value)
         elif wire_type in (WIRE_FIXED_32, WIRE_FIXED_64):
             fmt = _pack_fmt(meta.proto_type)
             value = struct.unpack(fmt, value)[0]

--- a/src/betterproto2/enum.py
+++ b/src/betterproto2/enum.py
@@ -30,17 +30,16 @@ class Enum(IntEnum):
     def from_string(cls, name: str) -> Self:
         """Return the value which corresponds to the string name.
 
-        Parameters
-        -----------
-        name: :class:`str`
-            The name of the enum member to get.
+        Parameters:
+            name: The name of the enum member to get.
 
-        Raises
-        -------
-        :exc:`ValueError`
-            The member was not found in the Enum.
+        Raises:
+            ValueError: The member was not found in the Enum.
+
+        Returns:
+            The corresponding value
         """
         try:
-            return cls._member_map_[name]
+            return cls[name]
         except KeyError as e:
             raise ValueError(f"Unknown value {name} for enum {cls.__name__}") from e

--- a/src/betterproto2/enum.py
+++ b/src/betterproto2/enum.py
@@ -1,141 +1,26 @@
-from __future__ import annotations
+from enum import IntEnum
 
-from enum import (
-    EnumMeta,
-    IntEnum,
-)
-from types import MappingProxyType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-)
-
-if TYPE_CHECKING:
-    from collections.abc import (
-        Generator,
-        Mapping,
-    )
-
-    from typing_extensions import (
-        Never,
-        Self,
-    )
+from typing_extensions import Self
 
 
-def _is_descriptor(obj: object) -> bool:
-    return hasattr(obj, "__get__") or hasattr(obj, "__set__") or hasattr(obj, "__delete__")
+class Enum(IntEnum):
+    @classmethod
+    def _missing_(cls, value):
+        # Create a new "unknown" instance with the given value.
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+        obj._name_ = None
+        return obj
 
-
-class EnumType(EnumMeta if TYPE_CHECKING else type):
-    _value_map_: Mapping[int, Enum]
-    _member_map_: Mapping[str, Enum]
-
-    def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any]) -> Self:
-        value_map = {}
-        member_map = {}
-
-        new_mcs = type(
-            f"{name}Type",
-            tuple(
-                dict.fromkeys([base.__class__ for base in bases if base.__class__ is not type] + [EnumType, type])
-            ),  # reorder the bases so EnumType and type are last to avoid conflicts
-            {"_value_map_": value_map, "_member_map_": member_map},
-        )
-
-        members = {
-            name: value for name, value in namespace.items() if not _is_descriptor(value) and not name.startswith("__")
-        }
-
-        cls = type.__new__(
-            new_mcs,
-            name,
-            bases,
-            {key: value for key, value in namespace.items() if key not in members},
-        )
-        # this allows us to disallow member access from other members as
-        # members become proper class variables
-
-        for name, value in members.items():
-            member = value_map.get(value)
-            if member is None:
-                member = cls.__new__(cls, name=name, value=value)  # type: ignore
-                value_map[value] = member
-            member_map[name] = member
-            type.__setattr__(new_mcs, name, member)
-
-        return cls
-
-    if not TYPE_CHECKING:
-
-        def __call__(cls, value: int) -> Enum:
-            try:
-                return cls._value_map_[value]
-            except (KeyError, TypeError):
-                raise ValueError(f"{value!r} is not a valid {cls.__name__}") from None
-
-        def __iter__(cls) -> Generator[Enum, None, None]:
-            yield from cls._member_map_.values()
-
-        def __reversed__(cls) -> Generator[Enum, None, None]:
-            yield from reversed(cls._member_map_.values())
-
-        def __getitem__(cls, key: str) -> Enum:
-            return cls._member_map_[key]
-
-        @property
-        def __members__(cls) -> MappingProxyType[str, Enum]:
-            return MappingProxyType(cls._member_map_)
-
-    def __repr__(cls) -> str:
-        return f"<enum {cls.__name__!r}>"
-
-    def __len__(cls) -> int:
-        return len(cls._member_map_)
-
-    def __setattr__(cls, name: str, value: Any) -> Never:
-        raise AttributeError(f"{cls.__name__}: cannot reassign Enum members.")
-
-    def __delattr__(cls, name: str) -> Never:
-        raise AttributeError(f"{cls.__name__}: cannot delete Enum members.")
-
-    def __contains__(cls, member: object) -> bool:
-        return isinstance(member, cls) and member.name in cls._member_map_
-
-
-class Enum(IntEnum if TYPE_CHECKING else int, metaclass=EnumType):
-    """
-    The base class for protobuf enumerations, all generated enumerations will
-    inherit from this. Emulates `enum.IntEnum`.
-    """
-
-    name: str | None
-    value: int
-
-    if not TYPE_CHECKING:
-
-        def __new__(cls, *, name: str | None, value: int) -> Self:
-            self = super().__new__(cls, value)
-            super().__setattr__(self, "name", name)
-            super().__setattr__(self, "value", value)
-            return self
-
-    def __str__(self) -> str:
-        return self.name or "None"
-
-    def __repr__(self) -> str:
+    def __str__(self):
+        if self.name is None:
+            return f"{self.__class__.__name__}.~UNKNOWN({self.value})"
         return f"{self.__class__.__name__}.{self.name}"
 
-    def __setattr__(self, key: str, value: Any) -> Never:
-        raise AttributeError(f"{self.__class__.__name__} Cannot reassign a member's attributes.")
-
-    def __delattr__(self, item: Any) -> Never:
-        raise AttributeError(f"{self.__class__.__name__} Cannot delete a member's attributes.")
-
-    def __copy__(self) -> Self:
-        return self
-
-    def __deepcopy__(self, memo: Any) -> Self:
-        return self
+    def __repr__(self):
+        if self.name is None:
+            return f"<{self.__class__.__name__}.~UNKNOWN: {self.value}>"
+        return super().__repr__()
 
     @classmethod
     def try_value(cls, value: int = 0) -> Self:
@@ -152,10 +37,7 @@ class Enum(IntEnum if TYPE_CHECKING else int, metaclass=EnumType):
             The corresponding member or a new instance of the enum if
             ``value`` isn't actually a member.
         """
-        try:
-            return cls._value_map_[value]
-        except (KeyError, TypeError):
-            return cls.__new__(cls, name=None, value=value)
+        return cls(value)
 
     @classmethod
     def from_string(cls, name: str) -> Self:

--- a/src/betterproto2/enum.py
+++ b/src/betterproto2/enum.py
@@ -6,38 +6,25 @@ from typing_extensions import Self
 class Enum(IntEnum):
     @classmethod
     def _missing_(cls, value):
+        # If the given value is not an integer, let the standard enum implementation raise an error
+        if not isinstance(value, int):
+            return None
+
         # Create a new "unknown" instance with the given value.
         obj = int.__new__(cls, value)
         obj._value_ = value
-        obj._name_ = None
+        obj._name_ = ""
         return obj
 
     def __str__(self):
-        if self.name is None:
+        if not self.name:
             return f"{self.__class__.__name__}.~UNKNOWN({self.value})"
         return f"{self.__class__.__name__}.{self.name}"
 
     def __repr__(self):
-        if self.name is None:
+        if not self.name:
             return f"<{self.__class__.__name__}.~UNKNOWN: {self.value}>"
         return super().__repr__()
-
-    @classmethod
-    def try_value(cls, value: int = 0) -> Self:
-        """Return the value which corresponds to the value.
-
-        Parameters
-        -----------
-        value: :class:`int`
-            The value of the enum member to get.
-
-        Returns
-        -------
-        :class:`Enum`
-            The corresponding member or a new instance of the enum if
-            ``value`` isn't actually a member.
-        """
-        return cls(value)
 
     @classmethod
     def from_string(cls, name: str) -> Self:

--- a/src/betterproto2/internal_lib/google/protobuf/__init__.py
+++ b/src/betterproto2/internal_lib/google/protobuf/__init__.py
@@ -47,7 +47,7 @@ import betterproto2
 
 from ...message_pool import default_message_pool
 
-betterproto2.check_compiler_version("0.2.0")
+betterproto2.check_compiler_version("0.3.0")
 
 
 class FieldCardinality(betterproto2.Enum):

--- a/src/betterproto2/internal_lib/google/protobuf/__init__.py
+++ b/src/betterproto2/internal_lib/google/protobuf/__init__.py
@@ -436,7 +436,7 @@ class Api(betterproto2.Message):
     Included interfaces. See [Mixin][].
     """
 
-    syntax: "Syntax" = betterproto2.field(7, betterproto2.TYPE_ENUM, default_factory=lambda: Syntax.try_value(0))
+    syntax: "Syntax" = betterproto2.field(7, betterproto2.TYPE_ENUM, default_factory=lambda: Syntax(0))
     """
     The source syntax of the service.
     """
@@ -646,7 +646,7 @@ class Enum(betterproto2.Message):
     The source context.
     """
 
-    syntax: "Syntax" = betterproto2.field(5, betterproto2.TYPE_ENUM, default_factory=lambda: Syntax.try_value(0))
+    syntax: "Syntax" = betterproto2.field(5, betterproto2.TYPE_ENUM, default_factory=lambda: Syntax(0))
     """
     The source syntax.
     """
@@ -691,13 +691,13 @@ class Field(betterproto2.Message):
     A single field of a message type.
     """
 
-    kind: "FieldKind" = betterproto2.field(1, betterproto2.TYPE_ENUM, default_factory=lambda: FieldKind.try_value(0))
+    kind: "FieldKind" = betterproto2.field(1, betterproto2.TYPE_ENUM, default_factory=lambda: FieldKind(0))
     """
     The field type.
     """
 
     cardinality: "FieldCardinality" = betterproto2.field(
-        2, betterproto2.TYPE_ENUM, default_factory=lambda: FieldCardinality.try_value(0)
+        2, betterproto2.TYPE_ENUM, default_factory=lambda: FieldCardinality(0)
     )
     """
     The field cardinality.
@@ -1065,7 +1065,7 @@ class Method(betterproto2.Message):
     Any metadata attached to the method.
     """
 
-    syntax: "Syntax" = betterproto2.field(7, betterproto2.TYPE_ENUM, default_factory=lambda: Syntax.try_value(0))
+    syntax: "Syntax" = betterproto2.field(7, betterproto2.TYPE_ENUM, default_factory=lambda: Syntax(0))
     """
     The source syntax of this method.
     """
@@ -1441,7 +1441,7 @@ class Type(betterproto2.Message):
     The source context.
     """
 
-    syntax: "Syntax" = betterproto2.field(6, betterproto2.TYPE_ENUM, default_factory=lambda: Syntax.try_value(0))
+    syntax: "Syntax" = betterproto2.field(6, betterproto2.TYPE_ENUM, default_factory=lambda: Syntax(0))
     """
     The source syntax.
     """

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -9,7 +9,6 @@ class Colour(betterproto2.Enum):
     BLUE = 3
 
 
-# PURPLE = Colour.__new__(Colour, name=None, value=4)
 PURPLE = Colour(4)
 
 
@@ -45,7 +44,7 @@ def test_repr(member: Colour, repr_value: str) -> None:
         (Colour.RED, ("RED", 1)),
         (Colour.GREEN, ("GREEN", 2)),
         (Colour.BLUE, ("BLUE", 3)),
-        (PURPLE, (None, 4)),
+        (PURPLE, ("", 4)),
     ],
 )
 def test_name_values(member: Colour, values: tuple[str | None, int]) -> None:
@@ -73,5 +72,5 @@ def test_from_string(member: Colour, input_str: str) -> None:
         (PURPLE, 4),
     ],
 )
-def test_try_value(member: Colour, input_int: int) -> None:
-    assert Colour.try_value(input_int) == member
+def test_construction(member: Colour, input_int: int) -> None:
+    assert Colour(input_int) == member

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -9,15 +9,17 @@ class Colour(betterproto2.Enum):
     BLUE = 3
 
 
-PURPLE = Colour.__new__(Colour, name=None, value=4)
+# PURPLE = Colour.__new__(Colour, name=None, value=4)
+PURPLE = Colour(4)
 
 
 @pytest.mark.parametrize(
     "member, str_value",
     [
-        (Colour.RED, "RED"),
-        (Colour.GREEN, "GREEN"),
-        (Colour.BLUE, "BLUE"),
+        (Colour.RED, "Colour.RED"),
+        (Colour.GREEN, "Colour.GREEN"),
+        (Colour.BLUE, "Colour.BLUE"),
+        (PURPLE, "Colour.~UNKNOWN(4)"),
     ],
 )
 def test_str(member: Colour, str_value: str) -> None:
@@ -27,9 +29,10 @@ def test_str(member: Colour, str_value: str) -> None:
 @pytest.mark.parametrize(
     "member, repr_value",
     [
-        (Colour.RED, "Colour.RED"),
-        (Colour.GREEN, "Colour.GREEN"),
-        (Colour.BLUE, "Colour.BLUE"),
+        (Colour.RED, "<Colour.RED: 1>"),
+        (Colour.GREEN, "<Colour.GREEN: 2>"),
+        (Colour.BLUE, "<Colour.BLUE: 3>"),
+        (PURPLE, "<Colour.~UNKNOWN: 4>"),
     ],
 )
 def test_repr(member: Colour, repr_value: str) -> None:


### PR DESCRIPTION
Enumerations used to rely on a complex mechanism using a metaclass to mimic the standard `IntEnum`. This PR simplifies this mechanism by relying directly on `IntEnum`.