### PR TITLE
Rename extras

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2627,11 +2627,11 @@ files = [
 
 [extras]
 all = ["grpcio", "grpclib"]
-grpc-async = ["grpclib"]
-grpc-sync = ["grpcio"]
+grpcio = ["grpcio"]
+grpclib = ["grpclib"]
 rust-codec = ["betterproto2-rust-codec"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "760b3debb0353238037a2c1479c1d3da9204420660a1569813d16c348c6eeec5"
+content-hash = "1c5b52976f63dccc304180ac52ea3d70bc0d584342cb29fd4d7bdc161b52ddf5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ Repository = "https://github.com/betterproto/python-betterproto2"
 
 [project.optional-dependencies]
 rust-codec = ["betterproto2-rust-codec"]
-grpc-sync = ["grpcio"]
-grpc-async = ["grpclib"]
+grpcio = ["grpcio"]
+grpclib = ["grpclib"]
 
 # betterproto2-rust-codec is not included because still experimental
 all = ["grpclib", "grpcio"]


### PR DESCRIPTION
In the future, betterproto will likely support async grpc with grpcio instead of grpclib. Thus, the naming of the extras didn't make sense