### PR TITLE
Make from_dict and from_json class methods

### DIFF
--- a/src/betterproto2/__init__.py
+++ b/src/betterproto2/__init__.py
@@ -28,7 +28,7 @@ from ._version import __version__, check_compiler_version
 from .casing import camel_case, safe_snake_case, snake_case
 from .enum import Enum as Enum
 from .grpc.grpclib_client import ServiceStub as ServiceStub
-from .utils import classproperty, hybridmethod
+from .utils import classproperty
 
 if TYPE_CHECKING:
     from _typeshed import SupportsRead, SupportsWrite
@@ -1087,8 +1087,8 @@ class Message(ABC):
             init_kwargs[field_name] = value
         return init_kwargs
 
-    @hybridmethod
-    def from_dict(cls: type[Self], value: Mapping[str, Any] | Any) -> Self:  # type: ignore
+    @classmethod
+    def from_dict(cls: type[Self], value: Mapping[str, Any] | Any) -> Self:
         """
         Parse the key/value pairs into the a new message instance.
 
@@ -1106,26 +1106,6 @@ class Message(ABC):
             return cls.from_wrapped(value)  # type: ignore
 
         return cls(**cls._from_dict_init(value))
-
-    @from_dict.instancemethod
-    def from_dict(self, value: Mapping[str, Any] | Any) -> Self:
-        """
-        Parse the key/value pairs into the current message instance. This returns the
-        instance itself and is therefore assignable and chainable.
-
-        Parameters
-        -----------
-        value: Dict[:class:`str`, Any]
-            The dictionary to parse from.
-
-        Returns
-        --------
-        :class:`Message`
-            The initialized message.
-        """
-        for field, value in self._from_dict_init(value).items():
-            setattr(self, field, value)
-        return self
 
     def to_json(
         self,
@@ -1164,7 +1144,8 @@ class Message(ABC):
             indent=indent,
         )
 
-    def from_json(self: T, value: str | bytes) -> T:
+    @classmethod
+    def from_json(cls, value: str | bytes) -> Self:
         """A helper function to return the message instance from its JSON
         representation. This returns the instance itself and is therefore assignable
         and chainable.
@@ -1183,7 +1164,7 @@ class Message(ABC):
         :class:`Message`
             The initialized message.
         """
-        return self.from_dict(json.loads(value))
+        return cls.from_dict(json.loads(value))
 
     def is_set(self, name: str) -> bool:
         """

--- a/src/betterproto2/utils.py
+++ b/src/betterproto2/utils.py
@@ -1,41 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import (
-    Any,
-    Concatenate,
-    Generic,
-    TypeVar,
-)
-
-from typing_extensions import (
-    ParamSpec,
-    Self,
-)
-
-SelfT = TypeVar("SelfT")
-P = ParamSpec("P")
-HybridT = TypeVar("HybridT", covariant=True)
-
-
-class hybridmethod(Generic[SelfT, P, HybridT]):
-    def __init__(
-        self,
-        func: Callable[Concatenate[type[SelfT], P], HybridT],  # Must be the classmethod version
-    ):
-        self.cls_func = func
-        self.__doc__ = func.__doc__
-
-    def instancemethod(self, func: Callable[Concatenate[SelfT, P], HybridT]) -> Self:
-        self.instance_func = func
-        return self
-
-    def __get__(self, instance: SelfT | None, owner: type[SelfT]) -> Callable[P, HybridT]:
-        if instance is None or self.instance_func is None:
-            # either bound to the class, or no instance method available
-            return self.cls_func.__get__(owner, None)
-        return self.instance_func.__get__(instance, owner)
-
+from typing import Any, Generic, TypeVar
 
 T_co = TypeVar("T_co")
 TT_co = TypeVar("TT_co", bound="type[Any]")

--- a/tests/inputs/oneof/test_oneof.py
+++ b/tests/inputs/oneof/test_oneof.py
@@ -5,16 +5,14 @@ from tests.util import get_test_case_json_data
 def test_which_count():
     from tests.output_betterproto.oneof import Test
 
-    message = Test()
-    message.from_json(get_test_case_json_data("oneof")[0].json)
+    message = Test.from_json(get_test_case_json_data("oneof")[0].json)
     assert betterproto2.which_one_of(message, "foo") == ("pitied", 100)
 
 
 def test_which_name():
     from tests.output_betterproto.oneof import Test
 
-    message = Test()
-    message.from_json(get_test_case_json_data("oneof", "oneof_name.json")[0].json)
+    message = Test.from_json(get_test_case_json_data("oneof", "oneof_name.json")[0].json)
     assert betterproto2.which_one_of(message, "foo") == ("pitier", "Mr. T")
 
 

--- a/tests/inputs/oneof_enum/test_oneof_enum.py
+++ b/tests/inputs/oneof_enum/test_oneof_enum.py
@@ -1,9 +1,5 @@
 import betterproto2
-from tests.output_betterproto.oneof_enum import (
-    Move,
-    Signal,
-    Test,
-)
+from tests.output_betterproto.oneof_enum import Move, Signal, Test
 from tests.util import get_test_case_json_data
 
 
@@ -11,8 +7,7 @@ def test_which_one_of_returns_enum_with_default_value():
     """
     returns first field when it is enum and set with default value
     """
-    message = Test()
-    message.from_json(get_test_case_json_data("oneof_enum", "oneof_enum-enum-0.json")[0].json)
+    message = Test.from_json(get_test_case_json_data("oneof_enum", "oneof_enum-enum-0.json")[0].json)
 
     assert message.move is None
     assert message.signal == Signal.PASS
@@ -23,8 +18,7 @@ def test_which_one_of_returns_enum_with_non_default_value():
     """
     returns first field when it is enum and set with non default value
     """
-    message = Test()
-    message.from_json(get_test_case_json_data("oneof_enum", "oneof_enum-enum-1.json")[0].json)
+    message = Test.from_json(get_test_case_json_data("oneof_enum", "oneof_enum-enum-1.json")[0].json)
 
     assert message.move is None
     assert message.signal == Signal.RESIGN
@@ -32,8 +26,7 @@ def test_which_one_of_returns_enum_with_non_default_value():
 
 
 def test_which_one_of_returns_second_field_when_set():
-    message = Test()
-    message.from_json(get_test_case_json_data("oneof_enum")[0].json)
+    message = Test.from_json(get_test_case_json_data("oneof_enum")[0].json)
     assert message.move == Move(x=2, y=3)
     assert message.signal is None
     assert betterproto2.which_one_of(message, "action") == ("move", Move(x=2, y=3))

--- a/tests/inputs/timestamp_dict_encode/test_timestamp_dict_encode.py
+++ b/tests/inputs/timestamp_dict_encode/test_timestamp_dict_encode.py
@@ -22,8 +22,7 @@ def test_datetime_dict_encode(tz: timezone):
     original_message = Test()
     original_message.ts = original_time
     encoded = original_message.to_dict()
-    decoded_message = Test()
-    decoded_message.from_dict(encoded)
+    decoded_message = Test.from_dict(encoded)
 
     # check that the timestamps are equal after decoding from dict
     assert original_message.ts.tzinfo is not None
@@ -37,8 +36,7 @@ def test_json_serialize(tz: timezone):
     original_message = Test()
     original_message.ts = original_time
     json_serialized = original_message.to_json()
-    decoded_message = Test()
-    decoded_message.from_json(json_serialized)
+    decoded_message = Test.from_json(json_serialized)
 
     # check that the timestamps are equal after decoding from dict
     assert original_message.ts.tzinfo is not None

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -382,10 +382,8 @@ iso_candidates = """2009-12-12T12:34
 def test_iso_datetime():
     from tests.output_betterproto.features import TimeMsg
 
-    msg = TimeMsg()
-
     for _, candidate in enumerate(iso_candidates):
-        msg.from_dict({"timestamp": candidate})
+        msg = TimeMsg.from_dict({"timestamp": candidate})
         assert isinstance(msg.timestamp, datetime)
 
 

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -169,9 +169,7 @@ def test_message_json(test_data: TestData) -> None:
         if sample.belongs_to(test_input_config.non_symmetrical_json):
             continue
 
-        message: betterproto2.Message = plugin_module.Test()
-
-        message.from_json(sample.json)
+        message: betterproto2.Message = plugin_module.Test.from_json(sample.json)
         message_json = message.to_json(indent=0)
 
         assert dict_replace_nans(json.loads(message_json)) == dict_replace_nans(json.loads(sample.json))


### PR DESCRIPTION
In almost all situations, `from_dict` and `from_json` are used to create a new message from data. Having an instance method doesn't make sense in these situations.

In the rare situations where the instance method could be useful, the name `from_dict` doesn't clearly describe what the instance method does: are the fields not part of the dict preserved? Are they reset to their default value? This can be a source of bugs.