### PR TITLE
Adding test and fix for backward compatibility in from dict

### DIFF
--- a/src/betterproto2/__init__.py
+++ b/src/betterproto2/__init__.py
@@ -1112,9 +1112,11 @@ class Message(ABC):
         init_kwargs: dict[str, Any] = {}
         for key, value in mapping.items():
             field_name = safe_snake_case(key)
-            field_cls = cls._betterproto.cls_by_field[field_name]
 
             try:
+                # To support backwards compatible additive changes, we wrap the accessing in a try except. If a field
+                # is not present in Message, but it is present in the mapping, we ignore it.
+                field_cls = cls._betterproto.cls_by_field[field_name]
                 meta = cls._betterproto.meta_by_field_name[field_name]
             except KeyError:
                 continue  # TODO is it a problem?

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -267,6 +267,20 @@ def test_to_dict_datetime_values():
     bytes(test)
 
 
+def test_from_dict_backward_compatibility():
+    from tests.output_betterproto.features import Newer, Older
+
+    newer = Newer(x=True, y=1, z="Hello")
+    dict_newer = newer.to_dict()
+
+    round_trip = Older.from_dict(dict_newer)
+
+    # ensure that there is no failure and extra fields y & z are ignored
+    expected_round_trip = Older(x=True)
+
+    assert expected_round_trip == round_trip
+
+
 def test_oneof_default_value_set_causes_writes_wire():
     from tests.output_betterproto.features import Empty, MsgC
 


### PR DESCRIPTION
## Summary
Moving `field_cls = cls._betterproto.cls_by_field[field_name]` to happen inside try except block. This is needed in the case in which there is an additive change which should be backwards compatible. The behavior when deserializing protobuf on the wire is to ignore extra fields, it would make sense to mimic this in `from_json` (which uses `from_dict` under the hood). 

<!-- What is this pull request for? Does it fix any issues? -->
This PR fixes a bug where if a field is added to a Message then `from_dict` raises a `KeyError`. This PR is not meant to be medium to discuss whether that is an appropriate behavior (though I think it is!. Since we wrap the `meta_by_field_name` call in the try except, it makes sense to include the `field_cls` fetch as well. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
