### PR TITLE
Fix negative enums

### DIFF
--- a/betterproto2/tests/inputs/enum/enum.json
+++ b/betterproto2/tests/inputs/enum/enum.json
@@ -4,6 +4,7 @@
     "ZERO",
     "ONE",
     "THREE",
-    "FOUR"
+    "FOUR",
+    "MINUS_ONE"
   ]
 }

--- a/betterproto2_compiler/src/betterproto2_compiler/templates/template.py.j2
+++ b/betterproto2_compiler/src/betterproto2_compiler/templates/template.py.j2
@@ -24,14 +24,6 @@ class {{ enum.py_name | add_to_all }}(betterproto2.Enum):
 
     {% endfor %}
 
-    {% if output_file.settings.pydantic_dataclasses %}
-    @classmethod
-    def __get_pydantic_core_schema__(cls, _source_type, _handler):
-        from pydantic_core import core_schema
-
-        return core_schema.int_schema(ge=0)
-    {% endif %}
-
     {% if enum.has_renamed_entries %}
     @classmethod
     def betterproto_value_to_renamed_proto_names(cls) -> dict[int, str]:

--- a/betterproto2_compiler/tests/inputs/enum/enum.proto
+++ b/betterproto2_compiler/tests/inputs/enum/enum.proto
@@ -14,6 +14,7 @@ enum Choice {
     // TWO = 2;
     FOUR = 4;
     THREE = 3;
+    MINUS_ONE = -1;
 }
 
 // A "C" like enum with the enum name prefixed onto members, these should be stripped


### PR DESCRIPTION
Protobuf explicitly allows negative values for enums, even if they are not recommended. Betterproto used to consider them as unsigned integers.