### PR TITLE
Add readme in pyproject.toml

### DIFF
--- a/betterproto2/pyproject.toml
+++ b/betterproto2/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 keywords = ["protobuf", "gRPC"]
 license = "MIT"
+readme = "../README.md"
 requires-python = ">=3.10,<4.0"
 dependencies = [
     "python-dateutil>=2.9.0.post0",

--- a/betterproto2_compiler/pyproject.toml
+++ b/betterproto2_compiler/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
     { name = "Daniel G. Taylor", email = "danielgtaylor@gmail.com" },
 ]
 license = "MIT"
+readme = "../README.md"
 keywords = [
     "protobuf",
     "gRPC",


### PR DESCRIPTION
## Summary

Fixes https://github.com/betterproto/python-betterproto2/issues/109

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
 
 
As per:
1. https://packaging.python.org/en/latest/specifications/pyproject-toml/
1. https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
1. https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/
 
Before:
 ```bash
 $ cd betterproto2
 $ uv build --wheel
 $ cd dist/
 $ 7z x betterproto2-0.9.1-py3-none-any.whl
 $ cat betterproto2-0.9.1.dist-info/METADATA 
Metadata-Version: 2.4
Name: betterproto2
Version: 0.9.1
Summary: A better Protobuf / gRPC generator & library
Project-URL: Documentation, https://betterproto.github.io/python-betterproto2/
Project-URL: Repository, https://github.com/betterproto/python-betterproto2
Author-email: Adrien Vannson <adrien.vannson@protonmail.com>, "Daniel G. Taylor" <danielgtaylor@gmail.com>
License-Expression: MIT
Keywords: gRPC,protobuf
Requires-Python: <4.0,>=3.10
Requires-Dist: python-dateutil>=2.9.0.post0
Requires-Dist: typing-extensions>=4.14.0
Provides-Extra: all
Requires-Dist: grpcio>=1.72.1; extra == 'all'
Requires-Dist: grpclib>=0.4.8; extra == 'all'
Requires-Dist: protobuf>=5.29.3; extra == 'all'
Requires-Dist: pydantic>=2.11.5; extra == 'all'
Provides-Extra: grpcio
Requires-Dist: grpcio>=1.72.1; extra == 'grpcio'
Provides-Extra: grpclib
Requires-Dist: grpclib>=0.4.8; extra == 'grpclib'
Provides-Extra: protobuf
Requires-Dist: protobuf>=5.29.3; extra == 'protobuf'
Provides-Extra: pydantic
Requires-Dist: pydantic>=2.11.5; extra == 'pydantic'
 ```
 
After:
 ```bash
 $ cd betterproto2
 $ uv build --wheel
 $ cd dist/
 $ 7z x betterproto2-0.9.1-py3-none-any.whl
 $ cat betterproto2-0.9.1.dist-info/METADATA 
Metadata-Version: 2.4
Name: betterproto2
Version: 0.9.1
Summary: A better Protobuf / gRPC generator & library
Project-URL: Documentation, https://betterproto.github.io/python-betterproto2/
Project-URL: Repository, https://github.com/betterproto/python-betterproto2
Author-email: Adrien Vannson <adrien.vannson@protonmail.com>, "Daniel G. Taylor" <danielgtaylor@gmail.com>
License-Expression: MIT
Keywords: gRPC,protobuf
Requires-Python: <4.0,>=3.10
Requires-Dist: python-dateutil>=2.9.0.post0
Requires-Dist: typing-extensions>=4.14.0
Provides-Extra: all
Requires-Dist: grpcio>=1.72.1; extra == 'all'
Requires-Dist: grpclib>=0.4.8; extra == 'all'
Requires-Dist: protobuf>=5.29.3; extra == 'all'
Requires-Dist: pydantic>=2.11.5; extra == 'all'
Provides-Extra: grpcio
Requires-Dist: grpcio>=1.72.1; extra == 'grpcio'
Provides-Extra: grpclib
Requires-Dist: grpclib>=0.4.8; extra == 'grpclib'
Provides-Extra: protobuf
Requires-Dist: protobuf>=5.29.3; extra == 'protobuf'
Provides-Extra: pydantic
Requires-Dist: pydantic>=2.11.5; extra == 'pydantic'
Description-Content-Type: text/markdown

# Better Protobuf / gRPC Support for Python

![](https://github.com/betterproto/python-betterproto2/actions/workflows/ci.yml/badge.svg)

> :warning: `betterproto2` is a fork of the original [`betterproto`](https://github.com/danielgtaylor/python-betterproto) repository. It is a major redesign of the library, allowing to fix several bugs and to support new features.
> 
> However, it is still in active developement. The documentation is not complete, there is still work to do and the project is still subject to breaking changes.

This project aims to provide an improved experience when using Protobuf / gRPC in a modern Python environment by making use of modern language features and generating readable, understandable, idiomatic Python code. It will not support legacy features or environments (e.g. Protobuf 2). The following are supported:

- Protobuf 3 & gRPC code generation
  - Both binary & JSON serialization is built-in
- Python 3.7+ making use of:
  - Enums
  - Dataclasses
  - `async`/`await`
  - Timezone-aware `datetime` and `timedelta` objects
  - Relative imports
  - Mypy type checking
- [Pydantic Models](https://docs.pydantic.dev/) generation


## Motivation

This project exists because of the following limitations of the Google protoc plugin for Python.

- No `async` support (requires additional `grpclib` plugin)
- No typing support or code completion/intelligence (requires additional `mypy` plugin)
- No `__init__.py` module files get generated
- Output is not importable
  - Import paths break in Python 3 unless you mess with `sys.path`
- Bugs when names clash (e.g. `codecs` package)
- Generated code is not idiomatic
  - Completely unreadable runtime code-generation
  - Much code looks like C++ or Java ported 1:1 to Python
  - Capitalized function names like `HasField()` and `SerializeToString()`
  - Uses `SerializeToString()` rather than the built-in `__bytes__()`
  - Special wrapped types don't use Python's `None`
  - Timestamp/duration types don't use Python's built-in `datetime` module

This project is a reimplementation from the ground up focused on idiomatic modern Python to help fix some of the above. While it may not be a 1:1 drop-in replacement due to changed method names and call patterns, the wire format is identical.

## Documentation

The documentation of betterproto is available online: https://betterproto.github.io/python-betterproto2/

## Development

- _Join us on [Discord](https://discord.gg/DEVteTupPb)!_

### Requirements

- Python (3.10 or higher)

- [poetry](https://python-poetry.org/docs/#installation)
  *Needed to install dependencies in a virtual environment*

- [poethepoet](https://github.com/nat-n/poethepoet) for running development tasks as defined in pyproject.toml
  - Can be installed to your host environment via `pip install poethepoet` then executed as simple `poe`
  - or run from the poetry venv as `poetry run poe`

## License

Copyright © 2019 Daniel G. Taylor

Copyright © 2024 The betterproto contributors
 ```
