### PR TITLE
Use uv_build instead of hatch

### DIFF
--- a/betterproto2/pyproject.toml
+++ b/betterproto2/pyproject.toml
@@ -50,8 +50,8 @@ package = true
 default-groups = "all"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.9.7,<0.10"]
+build-backend = "uv_build"
 
 [tool.ruff]
 extend-exclude = ["tests/outputs", "src/betterproto2/internal_lib"]

--- a/betterproto2_compiler/pyproject.toml
+++ b/betterproto2_compiler/pyproject.toml
@@ -52,8 +52,8 @@ package = true
 default-groups = "all"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.9.7,<0.10"]
+build-backend = "uv_build"
 
 [tool.ruff]
 extend-exclude = ["tests/outputs", "src/betterproto2_compiler/lib"]


### PR DESCRIPTION
## Summary

Use `uv_build` instead of `hatch`

The build system is a lot simpler/leaner/faster

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
 
