### PR TITLE
Move pytest config to pyproject.toml

### DIFF
--- a/betterproto2_compiler/pyproject.toml
+++ b/betterproto2_compiler/pyproject.toml
@@ -79,6 +79,12 @@ select = [
 [tool.ruff.lint.isort]
 combine-as-imports = true
 
+[tool.pytest.ini_options]
+python_files = "test_*.py"
+python_classes = ""
+norecursedirs = "**/output_*"
+addopts = "-p no:warnings"
+
 [tool.poe.tasks.test]
 cmd = "pytest"
 help = "Run tests"

--- a/betterproto2_compiler/pytest.ini
+++ b/betterproto2_compiler/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-python_files = test_*.py
-python_classes =
-norecursedirs = **/output_*
-addopts = -p no:warnings


### PR DESCRIPTION
## Summary

Move pytest config from pytest.ini to pyproject.toml

This was already done for the `betterproto2` package, now `betterproto2_compiler` does the same

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
 
