### PR TITLE
showcase broken case without explicit type in oneof pattern matching

### DIFF
--- a/betterproto2/tests/oneof_pattern_matching.py
+++ b/betterproto2/tests/oneof_pattern_matching.py
@@ -7,7 +7,7 @@ def test_oneof_pattern_matching():
     msg = OneofMsg(y="test1", b="test2")
 
     match msg:
-        case OneofMsg(x=int(_)):
+        case OneofMsg(x=_):
             pytest.fail("Matched 'bar' instead of 'baz'")
         case OneofMsg(y=v):
             assert v == "test1"


### PR DESCRIPTION
## Summary

this kind of match statement worked fine with python-betterproto, it seems to be a regression/breaking change in python-betterproto2

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
