### PR TITLE
Make ruff dependency less strict

### DIFF
--- a/betterproto2_compiler/pyproject.toml
+++ b/betterproto2_compiler/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # TODO use the version from the current repo?
     "betterproto2>=0.9.0,<0.10",
     # "betterproto2",
-    "ruff>=0.9.3,<0.15.0",
+    "ruff>=0.9.3",
     "jinja2>=3.0.3",
     "typing-extensions>=4.7.1,<5",
     "strenum>=0.4.15,<0.5 ; python_version == '3.10'",


### PR DESCRIPTION
This makes it less likely that projects which have this as a dependency will find themselves stuck

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
 
