### PR TITLE
help(MyMessage) crashes

### DIFF
--- a/betterproto2/src/betterproto2/__init__.py
+++ b/betterproto2/src/betterproto2/__init__.py
@@ -716,6 +716,9 @@ class Message(ABC):
         try:
             return cls._betterproto_meta
         except AttributeError:
+            if cls is Message:
+                # We can't generate metadata for the base class, only subclasses.
+                return None # type: ignore
             cls._betterproto_meta = ProtoClassMetadata(cls)
             return cls._betterproto_meta
 

--- a/betterproto2/tests/README.md
+++ b/betterproto2/tests/README.md
@@ -33,7 +33,7 @@ message Test {
 }
 ```
 
-You can add multiple `.proto` files to the test case, as long as one file matches the directory name. 
+You can add multiple `.proto` files to the test case, as long as one file matches the directory name.
 
 ### json
 
@@ -64,11 +64,11 @@ The following tests are automatically executed for all cases:
 - [x] Can the generated python code be imported?
 - [x] Can the generated message class be instantiated?
 - [x] Is the generated code compatible with the Google's `grpc_tools.protoc` implementation?
-  - _when `.json` is present_ 
+  - _when `.json` is present_
 
 ## Running the tests
 
-- `pipenv run generate`  
+- `pipenv run get-local-compiled-tests`
   This generates:
   - `betterproto/tests/output_betterproto` &mdash; *the plugin generated python classes*
   - `betterproto/tests/output_reference` &mdash; *reference implementation classes*

--- a/betterproto2/tests/test_documentation.py
+++ b/betterproto2/tests/test_documentation.py
@@ -60,3 +60,13 @@ Simple quotes are not escaped "
     Simple quotes are not escaped "
     """
         )
+
+
+def test_help(requires_grpclib) -> None:
+    """Test that help(Foo) doesn't trigger an error."""
+    from .outputs.documentation.documentation import Test
+
+    # help(Test) triggers help(Message)
+    # which inspects the class attribute Message._betterproto
+    # which is only supposed to be defined on subclasses of Message.
+    help(Test)


### PR DESCRIPTION
## Summary

Calling `help(MyMessage)` throws an error

```
/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pydoc.py:350: in classify_class_attrs
    for (name, kind, cls, value) in inspect.classify_class_attrs(object):
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/inspect.py:714: in classify_class_attrs
    srch_obj = getattr(srch_cls, name, None)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/betterproto2/utils.py:15: in __get__
    return self.__func__(type)
           ^^^^^^^^^^^^^^^^^^^
src/betterproto2/__init__.py:719: in _betterproto
    cls._betterproto_meta = ProtoClassMetadata(cls)
                            ^^^^^^^^^^^^^^^^^^^^^^^
src/betterproto2/__init__.py:494: in __init__
    assert dataclasses.is_dataclass(cls)
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
```

Unrelatedly, I updated the test readme with the correct command name `get-local-compiled-tests`

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
