### PR TITLE
Exclude dependabot PRs from changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,6 @@
+hangelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot[bot]

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,4 @@
-hangelog:
+changelog:
   exclude:
     labels:
       - ignore-for-release


### PR DESCRIPTION
This removes the dependabot PRs from the generated release notes, reducing noise