### PR TITLE
Remove README.md from pyproject.toml

### DIFF
--- a/betterproto2/pyproject.toml
+++ b/betterproto2/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 ]
 keywords = ["protobuf", "gRPC"]
 license = "MIT"
-readme = "../README.md"
 requires-python = ">=3.10,<4.0"
 dependencies = [
     "python-dateutil>=2.9.0.post0",

--- a/betterproto2_compiler/pyproject.toml
+++ b/betterproto2_compiler/pyproject.toml
@@ -7,7 +7,6 @@ authors = [
     { name = "Daniel G. Taylor", email = "danielgtaylor@gmail.com" },
 ]
 license = "MIT"
-readme = "../README.md"
 keywords = [
     "protobuf",
     "gRPC",


### PR DESCRIPTION
Having `README.md` in a parent folder made `uv build` fail.

Using a uv workspace would be more adapted.