### PR TITLE
Prevent generated RPC methods from being shadowed by ServiceStub parameters

### DIFF
--- a/betterproto2/src/betterproto2/grpclib/grpclib_client.py
+++ b/betterproto2/src/betterproto2/grpclib/grpclib_client.py
@@ -30,10 +30,31 @@ class ServiceStub(ABC):
         deadline: Optional["Deadline"] = None,
         metadata: MetadataLike | None = None,
     ) -> None:
-        self.channel = channel
-        self.timeout = timeout
-        self.deadline = deadline
-        self.metadata = metadata
+        # These are stored under private names and exposed through read-only
+        # properties so a generated RPC method whose name collides with one of
+        # them (e.g. an RPC named ``Metadata``) is not shadowed. A subclass
+        # method overrides the base property in the MRO, whereas an instance
+        # attribute would take precedence over the method.
+        self._channel = channel
+        self._timeout = timeout
+        self._deadline = deadline
+        self._metadata = metadata
+
+    @property
+    def channel(self) -> "Channel":
+        return self._channel
+
+    @property
+    def timeout(self) -> float | None:
+        return self._timeout
+
+    @property
+    def deadline(self) -> Optional["Deadline"]:
+        return self._deadline
+
+    @property
+    def metadata(self) -> MetadataLike | None:
+        return self._metadata
 
     def __resolve_request_kwargs(
         self,
@@ -42,9 +63,9 @@ class ServiceStub(ABC):
         metadata: MetadataLike | None,
     ):
         return {
-            "timeout": self.timeout if timeout is None else timeout,
-            "deadline": self.deadline if deadline is None else deadline,
-            "metadata": self.metadata if metadata is None else metadata,
+            "timeout": self._timeout if timeout is None else timeout,
+            "deadline": self._deadline if deadline is None else deadline,
+            "metadata": self._metadata if metadata is None else metadata,
         }
 
     async def _unary_unary(
@@ -58,7 +79,7 @@ class ServiceStub(ABC):
         metadata: MetadataLike | None = None,
     ) -> "T":
         """Make a unary request and return the response."""
-        async with self.channel.request(
+        async with self._channel.request(
             route,
             grpclib.const.Cardinality.UNARY_UNARY,
             type(request),
@@ -81,7 +102,7 @@ class ServiceStub(ABC):
         metadata: MetadataLike | None = None,
     ) -> AsyncIterator["T"]:
         """Make a unary request and return the stream response iterator."""
-        async with self.channel.request(
+        async with self._channel.request(
             route,
             grpclib.const.Cardinality.UNARY_STREAM,
             type(request),
@@ -104,7 +125,7 @@ class ServiceStub(ABC):
         metadata: MetadataLike | None = None,
     ) -> "T":
         """Make a stream request and return the response."""
-        async with self.channel.request(
+        async with self._channel.request(
             route,
             grpclib.const.Cardinality.STREAM_UNARY,
             request_type,
@@ -132,7 +153,7 @@ class ServiceStub(ABC):
         Make a stream request and return an AsyncIterator to iterate over response
         messages.
         """
-        async with self.channel.request(
+        async with self._channel.request(
             route,
             grpclib.const.Cardinality.STREAM_STREAM,
             request_type,

--- a/betterproto2/tests/grpc/test_service_stub_attributes.py
+++ b/betterproto2/tests/grpc/test_service_stub_attributes.py
@@ -1,0 +1,46 @@
+"""Regression tests for ServiceStub attribute handling.
+
+A generated RPC method is a class-level method on the ``ServiceStub`` subclass.
+If its snake_cased name happens to collide with one of the base constructor
+parameters (``channel``/``timeout``/``deadline``/``metadata`` — e.g. an RPC
+literally named ``Metadata``), storing those parameters as plain instance
+attributes would shadow the generated method, because an instance attribute
+takes precedence over a class method during attribute lookup. The base class
+keeps them under private names and exposes read-only properties instead, so a
+subclass method overrides the property in the MRO. See issue #224.
+"""
+
+import pytest
+
+from tests.mocks import MockChannel
+from tests.util import requires_grpclib  # noqa: F401
+
+
+@pytest.mark.asyncio
+async def test_rpc_method_not_shadowed_by_constructor_param(requires_grpclib):
+    from betterproto2.grpclib import ServiceStub
+
+    class _StubWithCollidingRpc(ServiceStub):
+        # Mimics a generated RPC named ``Metadata`` (snake_case ``metadata``),
+        # which collides with the ``metadata`` constructor parameter.
+        async def metadata(self):
+            return "rpc-result"
+
+    stub = _StubWithCollidingRpc(MockChannel(), metadata={"authorization": "token"})
+
+    assert callable(stub.metadata), "RPC method must not be shadowed by the parameter"
+    assert await stub.metadata() == "rpc-result"
+
+
+@pytest.mark.asyncio
+async def test_constructor_params_exposed_as_properties(requires_grpclib):
+    from betterproto2.grpclib import ServiceStub
+
+    channel = MockChannel()
+    metadata = {"authorization": "token"}
+    stub = ServiceStub(channel, timeout=12.5, metadata=metadata)
+
+    assert stub.channel is channel
+    assert stub.timeout == 12.5
+    assert stub.deadline is None
+    assert stub.metadata == metadata


### PR DESCRIPTION
Fixes #224.

## Problem

Generated RPC methods are class-level methods on the `ServiceStub` subclass. `ServiceStub.__init__` stored its `channel`/`timeout`/`deadline`/`metadata` parameters as plain instance attributes. When a generated RPC's snake_cased name collides with one of those names — e.g. an RPC literally named `Metadata` becomes `metadata` — the instance attribute shadows the class method, since instance attributes take precedence over class methods during attribute lookup. Calling the RPC then fails with `TypeError: 'dict' object is not callable` (or `'NoneType' object is not callable` when no metadata was passed).

## Fix

Store the four constructor parameters under private names (`self._channel`, etc.) and expose them through read-only `@property` accessors. A subclass method now overrides the base property in the MRO, so a colliding RPC method is reachable again. Non-colliding access (`stub.channel`, `stub.metadata`, …) still returns the parameter value exactly as before, so this is backwards compatible for normal reads. The properties are read-only; the parameters were never reassigned after `__init__`, so nothing in the codebase relied on writing to them.

## Tests

Added `tests/grpc/test_service_stub_attributes.py`:
- `test_rpc_method_not_shadowed_by_constructor_param` — a `ServiceStub` subclass defining an async `metadata` method (the colliding RPC); asserts the method is still callable and returns its own result. Fails before the change (`metadata` resolves to the dict), passes after.
- `test_constructor_params_exposed_as_properties` — asserts `channel`/`timeout`/`deadline`/`metadata` properties return the values passed to `__init__`.