### PR TITLE
Serialize negative zero floats instead of dropping them

### DIFF
--- a/betterproto2/src/betterproto2/__init__.py
+++ b/betterproto2/src/betterproto2/__init__.py
@@ -378,6 +378,17 @@ def _dump_float(value: float) -> float | str:
     return value
 
 
+def _is_negative_zero(value: object) -> bool:
+    """Return whether ``value`` is IEEE 754 negative zero.
+
+    ``-0.0`` compares equal to the ``0.0`` field default and is falsy, so the
+    naive "is this the default value?" checks treat it as unset and drop it.
+    It is a distinct value that the reference protobuf implementation
+    serializes, so the serializers must keep its sign.
+    """
+    return isinstance(value, float) and value == 0.0 and math.copysign(1.0, value) == -1.0
+
+
 def load_varint(stream: SupportsRead[bytes]) -> tuple[int, bytes]:
     """
     Load a single varint value from a stream. Returns the value and the raw bytes read.
@@ -586,7 +597,7 @@ def _value_to_dict(
         return value.to_dict(**kwargs), False
 
     if output_format == OutputFormat.PYTHON:
-        return value, not bool(value)
+        return value, not bool(value) and not _is_negative_zero(value)
 
     # PROTO_JSON
     if proto_type in INT_64_TYPES:
@@ -602,7 +613,7 @@ def _value_to_dict(
 
         return enum_value.proto_name or enum_value.name, not bool(value)
     if proto_type in (TYPE_FLOAT, TYPE_DOUBLE):
-        return _dump_float(value), not bool(value)
+        return _dump_float(value), not bool(value) and not _is_negative_zero(value)
     return value, not bool(value)
 
 
@@ -774,8 +785,10 @@ class Message(ABC):
                     # wrapper types and proto3 field presence/optional fields.
                     continue
 
-                if value == self._get_field_default(field_name):
-                    # Default (zero) values are not serialized.
+                if value == self._get_field_default(field_name) and not _is_negative_zero(value):
+                    # Default (zero) values are not serialized. Negative zero
+                    # equals the default but is a distinct value that the
+                    # reference implementation serializes, so it is kept.
                     continue
 
                 if meta.repeated:

--- a/betterproto2/tests/test_negative_zero.py
+++ b/betterproto2/tests/test_negative_zero.py
@@ -17,7 +17,7 @@ from betterproto2 import OutputFormat
 
 
 def _make_cls(proto_type: str):
-    @dataclass(eq=True)
+    @dataclass(eq=False, repr=False)
     class Msg(betterproto2.Message):
         v: float = betterproto2.field(1, proto_type)
 

--- a/betterproto2/tests/test_negative_zero.py
+++ b/betterproto2/tests/test_negative_zero.py
@@ -1,0 +1,57 @@
+"""Negative zero must survive serialization.
+
+``-0.0`` compares equal to the ``0.0`` field default and is falsy, so it used to
+be treated as unset and dropped from the binary wire format and from the
+``to_dict`` / ``to_json`` output. The reference protobuf implementation keeps
+``-0.0`` (its sign bit is set and distinguishes it from the default ``+0.0``), so
+a round trip must preserve the sign.
+"""
+
+import math
+from dataclasses import dataclass
+
+import pytest
+
+import betterproto2
+from betterproto2 import OutputFormat
+
+
+def _make_cls(proto_type: str):
+    @dataclass(eq=True)
+    class Msg(betterproto2.Message):
+        v: float = betterproto2.field(1, proto_type)
+
+    return Msg
+
+
+@pytest.mark.parametrize("proto_type", ["double", "float"])
+def test_negative_zero_is_written_to_the_wire(proto_type):
+    Msg = _make_cls(proto_type)
+
+    wire = bytes(Msg(v=-0.0))
+    assert wire, f"{proto_type} -0.0 was dropped from the binary output"
+
+    back = Msg().parse(wire)
+    assert back.v == 0.0
+    assert math.copysign(1.0, back.v) == -1.0
+
+
+@pytest.mark.parametrize("proto_type", ["double", "float"])
+@pytest.mark.parametrize("output_format", [OutputFormat.PROTO_JSON, OutputFormat.PYTHON])
+def test_negative_zero_is_kept_in_dict(proto_type, output_format):
+    Msg = _make_cls(proto_type)
+
+    as_dict = Msg(v=-0.0).to_dict(output_format=output_format)
+    assert "v" in as_dict, f"{proto_type} -0.0 was dropped from {output_format} output"
+
+    back = Msg().from_dict(as_dict)
+    assert math.copysign(1.0, back.v) == -1.0
+
+
+@pytest.mark.parametrize("proto_type", ["double", "float"])
+def test_positive_zero_default_is_still_omitted(proto_type):
+    # The actual default (+0.0) must keep being omitted everywhere.
+    Msg = _make_cls(proto_type)
+    assert bytes(Msg(v=0.0)) == b""
+    assert Msg(v=0.0).to_dict(output_format=OutputFormat.PROTO_JSON) == {}
+    assert Msg(v=0.0).to_dict(output_format=OutputFormat.PYTHON) == {}


### PR DESCRIPTION
## Problem

A `float` or `double` field set to `-0.0` is silently dropped during serialization. `-0.0` compares equal to the `0.0` field default and is falsy, so the "is this the default value?" checks treat it as unset and skip it.

The reference protobuf implementation keeps `-0.0`: its sign bit is set, which distinguishes it from the default `+0.0`.

```
# google.protobuf (reference), double field v = -0.0
wire: 090000000000000080      # 9 bytes, field present
json: {"v": -0.0}

# betterproto2 (before this PR), same field v = -0.0
wire: (empty)                 # field dropped, sign lost
json: {}
```

So a betterproto2 producer loses the sign for any consumer (including another betterproto2 process), while `+0.0` is correctly omitted. Decoding already worked: parsing the reference `-0.0` wire yields `-0.0`, so only the encode side was affected.

## Fix

Add a small `_is_negative_zero` helper and treat `-0.0` as a non-default value in the three serialization paths that relied on `value == default` / `not bool(value)`:

- binary `__bytes__`
- `to_dict` / `to_json` PROTO_JSON output
- `to_dict` PYTHON output

The real `+0.0` default keeps being omitted everywhere.

## Tests

`tests/test_negative_zero.py` checks that `-0.0` survives a binary round trip and a dict/json round trip for both `float` and `double`, and that `+0.0` is still omitted. The fixed binary output now matches the google reference byte for byte (`090000000000000080`).

## Notes

I found this with a differential test of betterproto2 against the google `protobuf` package. AI assistance was used under my direction; I verified the behavior against the reference implementation and reviewed the change.
