### PR TITLE
fix: avoid Pydantic namespace shadowing in Message.parse

### DIFF
--- a/betterproto2/src/betterproto2/__init__.py
+++ b/betterproto2/src/betterproto2/__init__.py
@@ -1019,7 +1019,13 @@ class Message(ABC):
         :class:`Message`
             The initialized message.
         """
+        # Do not leave the parameter named ``data`` in the local frame while
+        # constructing a Pydantic dataclass.  Generated modules commonly use
+        # a module-level ``data`` alias for nested enums; Pydantic's lazy
+        # forward-reference resolver can otherwise see this bytes argument
+        # and resolve ``data.SomeEnum`` against ``bytes``.
         with BytesIO(data) as stream:
+            del data
             return cls().load(stream)
 
     # For compatibility with other libraries.

--- a/betterproto2/tests/test_pydantic_forward_refs.py
+++ b/betterproto2/tests/test_pydantic_forward_refs.py
@@ -1,0 +1,32 @@
+from enum import IntEnum
+from types import SimpleNamespace
+
+from pydantic.dataclasses import dataclass
+
+import betterproto2
+
+
+@dataclass(eq=False, repr=False)
+class GeneratedMessage(betterproto2.Message):
+    # This mirrors python-betterproto2 output where a direct child package is
+    # imported as ``data`` after the class declarations.
+    namespace: "data.GeneratedNamespace" = betterproto2.field(
+        1,
+        betterproto2.TYPE_ENUM,
+        default_factory=lambda: data.GeneratedNamespace(0),
+    )
+
+
+class GeneratedNamespace(IntEnum):
+    UNKNOWN = 0
+
+
+data = SimpleNamespace(GeneratedNamespace=GeneratedNamespace)
+
+
+def test_pydantic_forward_reference_resolves_on_cold_parse():
+    assert GeneratedMessage.parse(b"").namespace is GeneratedNamespace.UNKNOWN
+
+
+def test_pydantic_forward_reference_resolves_for_keyword_data_argument():
+    assert GeneratedMessage.parse(data=b"").namespace is GeneratedNamespace.UNKNOWN


### PR DESCRIPTION
Generated Pydantic dataclasses can use a module-level `data` alias for nested enums. `Message.parse(data)` currently keeps its bytes parameter in the local frame while constructing the dataclass; Pydantic lazy forward-reference resolution can then resolve `data.SomeEnum` against `bytes` and fail on a legal payload.

This patch deletes the parameter after creating the BytesIO stream, before constructing the message. It preserves positional and keyword call compatibility and adds regression coverage for both forms using the generated-module shape.

Validated on Python 3.12 with the 0.9.1 library source and Pydantic 2.13.x.